### PR TITLE
Removed trailing baudrates

### DIFF
--- a/manifests/maverick-modules/maverick_mavlink/templates/mavlink-router.conf.erb
+++ b/manifests/maverick-modules/maverick_mavlink/templates/mavlink-router.conf.erb
@@ -17,7 +17,7 @@ Log=/srv/maverick/data/mavlink/<%= @name %>/logs
 <% elsif @inputtype == "serial" -%>
 [UartEndpoint serialin]
     Device=<%= @inputaddress %>
-    Baud=<%= @inputbaud %>,115200,57600
+    Baud=<%= @inputbaud %>
 <% end -%>
 
 <% (0..(@udpports.to_i()-1)).each do |i| -%>


### PR DESCRIPTION
Mavlink-router config file expects one baudrate for Uart Endpoint.  When ",115200,57600" is appended you get error "Invalid value '115200,115200,57600' for field 'baud'".