### PR TITLE
fix VERSION bug on initial install

### DIFF
--- a/bin/maverick
+++ b/bin/maverick
@@ -26,7 +26,7 @@ elif [ -f "../VERSION" ]; then
 else
     ver=""
 fi
-if [ -z $ver ]; then
+if [ -z "$ver" ]; then
     $ver = "n/a"
 fi
 echo


### PR DESCRIPTION
This is a picky and possibly unimportant bug related to the unboxing experience of getting started with maverick.

On a brand new raspian-lite image on a rpi3, after 'apt-get update', 'apt-get upgrade', then installing git and checking out the maverick repo, then 'cd' into it and running 'sudo ./bin/maverick --env=bootstrap configure', the first thing that happened was that I got this slightly discouraging feedback

    ./bin/maverick: line 30: =: command not found

    Maverick - UAV Companion Computer System - Version

Then it gets busy doing unsurprising and sensible looking stuff... how exciting, but that business about line 30 looks a bit rough, and so does the lack of version sting after ' - Version'.

So, this patch fixes the line in the script that identifies the version string on initial run (I suspect this problem does not manifest after the initial run.